### PR TITLE
Allow use/expose master keys

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -27,7 +27,14 @@ $ aws-vault exec work -- aws s3 ls
 another_bucket
 ```
 
+## Using master credentials
+In case you have a long living application and the server solution could
+not work for you, you can use master credentials. 
 
+It reduces security level as it exposes permanent credentials so we recommend using it only if needed and rotating the keys on a regular basis. 
+```bash
+$ aws-vault exec work --use-master-keys -- <long living application, ie: rails s >
+```
 ## Overriding the aws CLI to use aws-vault
 
 You can create an overriding script (make it higher precedence in your PATH) that looks like the below:

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -385,6 +385,18 @@ type VaultCredentials struct {
 	provider *VaultProvider
 }
 
+
+func MasterCreds(k keyring.Keyring, profile string, opts VaultOptions) (*credentials.Value, error) {
+	provider, err := NewVaultProvider(k, profile, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	master_creds, _ := provider.getMasterCreds()
+
+	return &master_creds, nil
+}
+
 func NewVaultCredentials(k keyring.Keyring, profile string, opts VaultOptions) (*VaultCredentials, error) {
 	provider, err := NewVaultProvider(k, profile, opts)
 	if err != nil {


### PR DESCRIPTION
Using temporary keys requires is sometimes not possible for long living applications. Or require use of a specific setup to enable aws-vault server which is not correctly working so far.